### PR TITLE
Fix(style): Make background transparent for some components

### DIFF
--- a/src/lib/dropdown/simple-button.tsx
+++ b/src/lib/dropdown/simple-button.tsx
@@ -6,7 +6,7 @@ import { borderBox, button, svg, small, h1 } from "../../styles/common-style";
 const Container = styled.button`
   ${borderBox}
   ${button}
-  background: ${({ theme }) => theme.whiteBackground};
+  background: none;
   display: flex;
   align-items: center;
   padding: 0px;

--- a/src/lib/pagination/tabs.tsx
+++ b/src/lib/pagination/tabs.tsx
@@ -15,7 +15,7 @@ const StyledTab = styled.button<{ selected?: boolean }>`
   ${button}
   flex-grow: 1;
   height: 45px;
-  background: ${(props) => props.theme.lightBackground};
+  background: none;
   border-bottom: 3px solid
     ${(props) =>
       props.selected ? props.theme.primaryBlue : props.theme.stroke};


### PR DESCRIPTION
Make background transparent for dropdown simple button and tabs component, since we don't know on which background they could be used.