### PR TITLE
feat(web): tiny-margin-adjustment on accordions

### DIFF
--- a/src/lib/accordion/accordion-item.tsx
+++ b/src/lib/accordion/accordion-item.tsx
@@ -6,7 +6,6 @@ import Minus from "../../assets/svgs/accordion/minus.svg";
 import { svg, button } from "../../styles/common-style";
 
 const StyledDiv = styled.div`
-  margin: 8px 0px;
   .accordion-button {
     ${button}
     width: 100%;


### PR DESCRIPTION
I did this because of a conflict between margins between Accordions and Cards, related to [this issue in V2](https://github.com/kleros/kleros-v2/issues/1476)