### PR TITLE
fix(web): pass-icon-prop-to-base-item-in-dropdown-select

### DIFF
--- a/src/lib/dropdown/select/item-container.tsx
+++ b/src/lib/dropdown/select/item-container.tsx
@@ -38,13 +38,13 @@ const ItemContainer: React.FC<IItemContainer> = ({
   onChange,
 }) => (
   <BaseItemContainer>
-    {items.map(({ text, Icon, dot, value }, i) => (
+    {items.map(({ text, Icon, icon, dot, value }, i) => (
       <StyledItem
         key={i}
         tabIndex={0}
         selected={value === selected}
         onClick={() => onChange(value)}
-        {...{ text, dot, Icon }}
+        {...{ text, dot, Icon, icon }}
       />
     ))}
   </BaseItemContainer>


### PR DESCRIPTION
Fixes icon not showing in Dropdown Select Container when passed through `icon` prop 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `item-container.tsx` file in the dropdown select component to include a new `icon` property in the items mapping.

### Detailed summary
- Added a new `icon` property in the items mapping
- Updated the spread operator to include the `icon` property alongside `text`, `dot`, and `Icon`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->