### PR TITLE
fix(web): no-margin-bottom-on-last-timeline-bullet

### DIFF
--- a/src/lib/progress/timeline/bullet.tsx
+++ b/src/lib/progress/timeline/bullet.tsx
@@ -18,22 +18,21 @@ const StyledTitle = styled.h2``;
 const StyledParty = styled.p``;
 const StyledSubtitle = styled.small``;
 
-const TextContainer = styled.div<SideProp & VariantProp>`
+const TextContainer = styled.div<SideProp & VariantProp & { isLast: boolean }>`
   margin-${({ rightSided }) => (rightSided ? "left" : "right")}: 20px;
   order: ${({ rightSided }) => (rightSided ? 1 : -1)};
   display: flex;
   flex-direction: column;  
-  margin-bottom: 18px;
+  margin-bottom: ${({ isLast }) => (isLast ? "0" : "18px")};
   gap: 2px;
   text-align: ${({ rightSided }) => (rightSided ? "left" : "right")};
 
   @media (max-width: 900px) {
     margin-${({ rightSided }) => (rightSided ? "left" : "right")}: 16px;
-    margin-bottom: 16px;
+    margin-bottom: ${({ isLast }) => (isLast ? "0" : "16px")};
     gap: 4px;
-
   }
-  
+
   & ${StyledTitle} {
     ${h2}
     order: ${({ rightSided }) => (rightSided ? 1 : 2)};
@@ -75,16 +74,18 @@ interface BulletProps extends VariantProp, SideProp {
   active?: boolean;
   Icon?: React.FC<React.SVGAttributes<SVGElement>>;
   line?: boolean;
+  isLast: boolean;
 }
 
 const Bullet: React.FC<BulletProps> = (props) => {
   const { title, party, subtitle, ...restProps } = props;
-  const { rightSided, variant, line, Icon, ...wrapperProps } = restProps;
+  const { rightSided, variant, line, Icon, isLast, ...wrapperProps } =
+    restProps;
 
   return (
     <Wrapper {...{ rightSided }} {...wrapperProps}>
       <Spine {...{ variant, line, Icon }} />
-      <TextContainer {...{ variant, rightSided }}>
+      <TextContainer {...{ variant, rightSided, isLast }}>
         <PartyTitleContainer {...{ rightSided }}>
           <StyledTitle>{title}</StyledTitle>
           <StyledParty>{party}</StyledParty>

--- a/src/lib/progress/timeline/custom.tsx
+++ b/src/lib/progress/timeline/custom.tsx
@@ -34,9 +34,9 @@ const CustomTimeline: React.FC<ICustomTimelineProps> = ({
   return (
     <Wrapper {...props}>
       {items.slice(0, -1).map((item, i) => (
-        <Bullet key={i} line {...item} rightSided />
+        <Bullet key={i} line {...item} rightSided isLast={false} />
       ))}
-      <LastBullet rightSided {...lastItem} />
+      <LastBullet rightSided {...lastItem} isLast={true} />
     </Wrapper>
   );
 };

--- a/src/lib/progress/timeline/index.tsx
+++ b/src/lib/progress/timeline/index.tsx
@@ -37,9 +37,9 @@ const Timeline: React.FC<TimelineProps> = ({ items, ...props }) => {
   return (
     <Wrapper {...props}>
       {items.slice(0, -1).map((item, i) => (
-        <StyledBullet key={i} line {...item} />
+        <StyledBullet key={i} line {...item} isLast={false} />
       ))}
-      <LastBullet {...lastItem} />
+      <LastBullet {...lastItem} isLast={true} />
     </Wrapper>
   );
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add an `isLast` prop to the `Bullet` component in the timeline feature for better styling of the last item.

### Detailed summary
- Added `isLast` prop to `Bullet` component in timeline
- Updated `TextContainer` styling based on `isLast` prop
- Updated `Bullet` component props to include `isLast` prop

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->