### PR TITLE
fix: fix-overflow-set-to-hidden-on-expanded-accordion

### DIFF
--- a/src/lib/accordion/accordion-item.tsx
+++ b/src/lib/accordion/accordion-item.tsx
@@ -33,7 +33,7 @@ interface CollapsibleProps {
 
 const Collapsible = styled.div<CollapsibleProps>`
   height: ${(props) => (props.expanded ? props.totalHeight.toString() : "0")}px;
-  overflow: hidden;
+  overflow: ${(props) => (props.expanded ? "visible" : "hidden")};
   transition: height ease
     ${({ theme }) => theme.klerosUIComponentsTransitionSpeed};
 `;


### PR DESCRIPTION
Fixes a styling issue in Accordion

-  On expanded state `overflow` is set to `hidden`, making components like tooltips not visible completely

### Before
<img width="854" alt="Screenshot 2024-04-05 at 6 11 47 PM" src="https://github.com/kleros/ui-components-library/assets/51452848/e244bd7b-ffd9-4fb7-8c57-7aa4d857deb6">

### After
<img width="847" alt="Screenshot 2024-04-05 at 6 11 13 PM" src="https://github.com/kleros/ui-components-library/assets/51452848/750f3e79-f784-421b-a10b-771e27b7ee7d">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `overflow` property in the `Collapsible` styled component in `accordion-item.tsx` to be `visible` when expanded.

### Detailed summary
- Updated `overflow` property in `Collapsible` styled component to be `visible` when expanded.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->