### PR TITLE
feat: add-default-expanded-item-in-accordion

### DIFF
--- a/src/lib/accordion/index.tsx
+++ b/src/lib/accordion/index.tsx
@@ -19,6 +19,7 @@ interface AccordionItem {
 
 interface AccordionProps {
   items: AccordionItem[];
+  defaultExpanded?: number;
 }
 
 const AccordionTitle = styled.p`
@@ -36,8 +37,12 @@ const DefaultTitle: React.FC<{ item: AccordionItem }> = ({ item }) => (
   </>
 );
 
-const Accordion: React.FC<AccordionProps> = ({ items, ...props }) => {
-  const [expanded, setExpanded] = useState(-1);
+const Accordion: React.FC<AccordionProps> = ({
+  items,
+  defaultExpanded,
+  ...props
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded ?? -1);
   return (
     <Wrapper {...props}>
       {items.map((item, index) => (


### PR DESCRIPTION
- Adds prop `defaultExpanded` to optionally specify which item to have expanded by default in the Accordion.
- It's only for the initial load, i.e, the item will only be expanded at initial load and can be collapsed 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a `defaultExpanded` prop to the `Accordion` component in the `AccordionProps` interface, allowing the component to start with a specific item expanded by default.

### Detailed summary
- Added `defaultExpanded` prop to `AccordionProps`
- Initialized `expanded` state based on `defaultExpanded` prop or `-1` if not provided

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->