### PR TITLE
feat: datepicker improvements

### DIFF
--- a/src/lib/dropdown/select/index.tsx
+++ b/src/lib/dropdown/select/index.tsx
@@ -62,7 +62,10 @@ const Select: React.FC<ISelect> = ({
           {...{ items, selected }}
           onChange={(value: IItem["value"]) => {
             new Promise((resolve) => resolve(callback(value)))
-              .then(() => setSelected(value))
+              .then(() => {
+                setSelected(value);
+                setIsOpen(false);
+              })
               .catch((error) => console.error(error));
           }}
         />

--- a/src/lib/form/datepicker/day.tsx
+++ b/src/lib/form/datepicker/day.tsx
@@ -16,6 +16,7 @@ const StyledDayNumber = styled.small<{
       ? props.theme.klerosUIComponentsStroke
       : props.theme.klerosUIComponentsSecondaryText} !important;
   font-weight: 600;
+  cursor: ${(props) => (props.disabledDate ? "not-allowed" : "pointer")};
 `;
 
 const StyledButton = styled.button<{
@@ -42,7 +43,6 @@ const StyledButton = styled.button<{
         : props.disabledDate
         ? props.theme.klerosUIComponentsWhiteBackground
         : props.theme.klerosUIComponentsSecondaryBlue};
-    cursor: pointer;
     & ${StyledDayNumber} {
       color: ${(props) =>
         props.disabledDate

--- a/src/lib/form/datepicker/day.tsx
+++ b/src/lib/form/datepicker/day.tsx
@@ -4,16 +4,24 @@ import { useDay } from "@datepicker-react/hooks";
 import DatepickerContext from "./datepickerContext";
 import { button, small } from "../../../styles/common-style";
 
-const StyledDayNumber = styled.small<{ isSelected: boolean }>`
+const StyledDayNumber = styled.small<{
+  isSelected: boolean;
+  disabledDate: boolean;
+}>`
   ${small}
   color: ${(props) =>
     props.isSelected
       ? props.theme.klerosUIComponentsWhiteBackground
+      : props.disabledDate
+      ? props.theme.klerosUIComponentsStroke
       : props.theme.klerosUIComponentsSecondaryText} !important;
   font-weight: 600;
 `;
 
-const StyledButton = styled.button<{ isSelected: boolean }>`
+const StyledButton = styled.button<{
+  isSelected: boolean;
+  disabledDate: boolean;
+}>`
   ${button}
   height: 24px;
   width: 24px;
@@ -31,11 +39,15 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
     background-color: ${(props) =>
       props.isSelected
         ? props.theme.klerosUIComponentsPrimaryBlue
+        : props.disabledDate
+        ? props.theme.klerosUIComponentsWhiteBackground
         : props.theme.klerosUIComponentsSecondaryBlue};
     cursor: pointer;
     & ${StyledDayNumber} {
-      color: ${({ theme }) =>
-        theme.klerosUIComponentsWhiteBackground} !important;
+      color: ${(props) =>
+        props.disabledDate
+          ? props.theme.klerosUIComponentsStroke
+          : props.theme.klerosUIComponentsWhiteBackground} !important;
     }
   }
 `;
@@ -52,12 +64,32 @@ const Day: React.FC<IDay> = ({ date, dayLabel }) => {
     date,
     ...useContext(DatepickerContext),
   });
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const isPastDate = date.getTime() < today.getTime();
+
+  const handleClick = () => {
+    if (!isPastDate) {
+      onClick();
+    }
+  };
+
   return (
     <StyledButton
       ref={dayRef}
-      {...{ isSelected, onClick, onKeyDown, onMouseEnter, tabIndex }}
+      {...{
+        isSelected,
+        onClick: handleClick,
+        onKeyDown,
+        onMouseEnter,
+        tabIndex,
+        disabledDate: isPastDate,
+      }}
     >
-      <StyledDayNumber {...{ isSelected }}>{dayLabel}</StyledDayNumber>
+      <StyledDayNumber {...{ isSelected, disabledDate: isPastDate }}>
+        {dayLabel}
+      </StyledDayNumber>
     </StyledButton>
   );
 };

--- a/src/lib/form/datepicker/index.tsx
+++ b/src/lib/form/datepicker/index.tsx
@@ -34,7 +34,7 @@ const DatePicker: React.FC<IDatePicker> = ({ onSelect, time }) => {
     isDateFocused,
     focusedDate,
     onDateHover,
-    onDateSelect,
+    onDateSelect: handleDateSelect,
     onDateFocus,
     goToPreviousMonths,
     goToNextMonths,
@@ -46,12 +46,30 @@ const DatePicker: React.FC<IDatePicker> = ({ onSelect, time }) => {
       if (date.startDate) {
         date.startDate.setHours(hours, minutes);
         setDate(date.startDate);
+        onSelect(date.startDate);
       }
     },
     numberOfMonths: 1,
     minBookingDays: 1,
     exactMinBookingDays: true,
   });
+
+  const onDateSelect = (date: Date) => {
+    handleDateSelect(date);
+    date.setHours(hours, minutes);
+    setDate(date);
+    onSelect(date);
+  };
+
+  const onTimeChange = (hours: number, minutes: number) => {
+    const newDate = new Date(date);
+    newDate.setHours(hours, minutes);
+    setHours(hours);
+    setMinutes(minutes);
+    setDate(newDate);
+    onSelect(newDate);
+  };
+
   return (
     <DatepickerContext.Provider
       value={{
@@ -79,8 +97,8 @@ const DatePicker: React.FC<IDatePicker> = ({ onSelect, time }) => {
             date,
             hours,
             minutes,
-            setHours,
-            setMinutes,
+            setHours: (hours) => onTimeChange(hours, minutes),
+            setMinutes: (minutes) => onTimeChange(hours, minutes),
             onSelect: () => {
               date.setHours(hours, minutes);
               onSelect(date);

--- a/src/lib/form/datepicker/time-controls.tsx
+++ b/src/lib/form/datepicker/time-controls.tsx
@@ -83,68 +83,92 @@ const TimeControls: React.FC<ITimeControls> = ({
   minutes,
   setHours,
   setMinutes,
-}) => (
-  <TimeControl>
-    <TimeButtons>
-      <UnstyledButton
-        onClick={() => {
-          const newHours = hours + 1;
-          setHours(newHours);
-          date.setHours(newHours, minutes);
-        }}
-        disabled={hours === 23}
-      >
-        <UpArrow />
-      </UnstyledButton>
-      <UnstyledButton
-        onClick={() => {
-          const newMinutes = minutes + 1;
-          setMinutes(newMinutes);
-          date.setHours(hours, newMinutes);
-        }}
-        disabled={minutes === 59}
-      >
-        <UpArrow />
-      </UnstyledButton>
-    </TimeButtons>
-    <TimeDisplay>
-      <StyledTime>
-        {hours.toLocaleString("en-US", {
-          minimumIntegerDigits: 2,
-          useGrouping: false,
-        })}
-      </StyledTime>
-      <StyledTime>:</StyledTime>
-      <StyledTime>
-        {minutes.toLocaleString("en-US", {
-          minimumIntegerDigits: 2,
-          useGrouping: false,
-        })}
-      </StyledTime>
-    </TimeDisplay>
-    <TimeButtons>
-      <UnstyledButton
-        onClick={() => {
-          const newHours = hours - 1;
-          setHours(newHours);
-          date.setHours(newHours, minutes);
-        }}
-        disabled={hours === 0}
-      >
-        <DownArrow />
-      </UnstyledButton>
-      <UnstyledButton
-        onClick={() => {
-          const newMinutes = minutes - 1;
-          setMinutes(newMinutes);
-          date.setHours(hours, newMinutes);
-        }}
-        disabled={minutes === 0}
-      >
-        <DownArrow />
-      </UnstyledButton>
-    </TimeButtons>
-  </TimeControl>
-);
+}) => {
+  const today = new Date();
+
+  const disableHourUp = hours === 23;
+  const disableMinuteUp = minutes === 59;
+
+  const isToday = date.toDateString() === today.toDateString();
+  const currentTime = today.getTime();
+  const checkTime = new Date(date).setHours(hours - 1, minutes);
+
+  const disableHourDown =
+    hours === 0 ||
+    (isToday &&
+      (hours - 1 < today.getHours() ||
+        (hours - 1 === today.getHours() && minutes <= today.getMinutes()) ||
+        checkTime <= currentTime));
+
+  const disableMinuteDown =
+    minutes === 0 ||
+    (isToday &&
+      (hours < today.getHours() ||
+        (hours === today.getHours() && minutes - 1 <= today.getMinutes())));
+
+  return (
+    <TimeControl>
+      <TimeButtons>
+        <UnstyledButton
+          onClick={() => {
+            const newHours = hours + 1;
+            setHours(newHours);
+            date.setHours(newHours, minutes);
+          }}
+          disabled={disableHourUp}
+        >
+          <UpArrow />
+        </UnstyledButton>
+        <UnstyledButton
+          onClick={() => {
+            const newMinutes = minutes + 1;
+            setMinutes(newMinutes);
+            date.setHours(hours, newMinutes);
+          }}
+          disabled={disableMinuteUp}
+        >
+          <UpArrow />
+        </UnstyledButton>
+      </TimeButtons>
+      <TimeDisplay>
+        <StyledTime>
+          {hours.toLocaleString("en-US", {
+            minimumIntegerDigits: 2,
+            useGrouping: false,
+          })}
+        </StyledTime>
+        <StyledTime>:</StyledTime>
+        <StyledTime>
+          {minutes.toLocaleString("en-US", {
+            minimumIntegerDigits: 2,
+            useGrouping: false,
+          })}
+        </StyledTime>
+      </TimeDisplay>
+      <TimeButtons>
+        <UnstyledButton
+          onClick={() => {
+            const newHours = hours - 1;
+            setHours(newHours);
+            date.setHours(newHours, minutes);
+          }}
+          disabled={disableHourDown}
+        >
+          <DownArrow />
+        </UnstyledButton>
+        <UnstyledButton
+          onClick={() => {
+            const newMinutes = minutes - 1;
+            setMinutes(newMinutes);
+            date.setHours(hours, newMinutes);
+          }}
+          disabled={disableMinuteDown}
+        >
+          <DownArrow />
+        </UnstyledButton>
+      </TimeButtons>
+    </TimeControl>
+  );
+};
 
 export default TimeControls;


### PR DESCRIPTION
Things added:

- Disabled selection of past dates (is this completely desirable? for example, for Escrow it makes sense because we only want future dates enabled, AND the following is not needed now and we can backlog it, but for some App that we want to select between 2 Dates (including past dates) for filtering, then this won't enable that. We could make it ... optional, like disablePastDates optional? + make year possible to change directly too
- Date state is now set whenever you click any day or hour or minute, without having to explicitly click on the "Select" button, which is now optional.
- fixed "unselected" date bug that happened when changing time
- reset time to current time when selecting lastSelectableDate (date===day, in this context) to avoid people selecting previous time

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances dropdown functionality in `select`, updates styling in `day` and `datepicker`, and refactors time controls in `time-controls`.

### Detailed summary
- Improved dropdown behavior with `setSelected` and `setIsOpen`.
- Updated styling in `day` and `datepicker` components.
- Refactored time controls for better usability and disabled state handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->