### PR TITLE
feat: optional close button on last pagination page on compact pagination

### DIFF
--- a/src/hooks/pagination/use-pagination.tsx
+++ b/src/hooks/pagination/use-pagination.tsx
@@ -1,7 +1,6 @@
 const usePagination = (
   currentPage: number,
   numPages: number,
-  //eslint-disable-next-line @typescript-eslint/ban-types
   callback: (newPage: number) => void,
   onCloseOnLastPage?: () => void,
   numNeighbors = 2

--- a/src/hooks/pagination/use-pagination.tsx
+++ b/src/hooks/pagination/use-pagination.tsx
@@ -2,7 +2,7 @@ const usePagination = (
   currentPage: number,
   numPages: number,
   //eslint-disable-next-line @typescript-eslint/ban-types
-  callback: Function,
+  callback: (newPage: number) => void,
   onCloseOnLastPage?: () => void,
   numNeighbors = 2
 ) => {

--- a/src/hooks/pagination/use-pagination.tsx
+++ b/src/hooks/pagination/use-pagination.tsx
@@ -3,12 +3,12 @@ const usePagination = (
   numPages: number,
   //eslint-disable-next-line @typescript-eslint/ban-types
   callback: Function,
-  closeOnLastPage?: () => void,
+  onCloseOnLastPage?: () => void,
   numNeighbors = 2
 ) => {
   const incrementPage = () => {
-    if (currentPage === numPages && closeOnLastPage) {
-      closeOnLastPage();
+    if (currentPage === numPages && onCloseOnLastPage) {
+      onCloseOnLastPage();
     } else {
       const newPage = Math.min(numPages, currentPage + 1);
       callback(newPage);

--- a/src/hooks/pagination/use-pagination.tsx
+++ b/src/hooks/pagination/use-pagination.tsx
@@ -3,11 +3,16 @@ const usePagination = (
   numPages: number,
   //eslint-disable-next-line @typescript-eslint/ban-types
   callback: Function,
+  closeOnLastPage?: () => void,
   numNeighbors = 2
 ) => {
   const incrementPage = () => {
-    const newPage = Math.min(numPages, currentPage + 1);
-    callback(newPage);
+    if (currentPage === numPages && closeOnLastPage) {
+      closeOnLastPage();
+    } else {
+      const newPage = Math.min(numPages, currentPage + 1);
+      callback(newPage);
+    }
   };
 
   const decrementPage = () => {

--- a/src/lib/pagination/compact.tsx
+++ b/src/lib/pagination/compact.tsx
@@ -77,7 +77,7 @@ interface CompactPaginationProps {
   numPages: number;
   //eslint-disable-next-line @typescript-eslint/ban-types
   callback: Function;
-  closeOnLastPage?: () => void;
+  onCloseOnLastPage?: () => void;
   label?: ReactNode;
   className?: string;
 }
@@ -86,12 +86,12 @@ const CompactPagination: React.FC<CompactPaginationProps> = ({
   currentPage,
   numPages,
   callback,
-  closeOnLastPage,
+  onCloseOnLastPage,
   label,
   className,
 }) => {
   const [{ incrementPage, decrementPage, minPageReached, maxPageReached }] =
-    usePagination(currentPage, numPages, callback, closeOnLastPage);
+    usePagination(currentPage, numPages, callback, onCloseOnLastPage);
 
   return (
     <Wrapper {...{ className }}>
@@ -99,8 +99,8 @@ const CompactPagination: React.FC<CompactPaginationProps> = ({
       <LeftArrow disabled={minPageReached} onClick={decrementPage}>
         <Arrow className={StyledSVG.styledComponentId} />
       </LeftArrow>
-      {currentPage === numPages && closeOnLastPage ? (
-        <CloseButton onClick={closeOnLastPage}>
+      {currentPage === numPages && onCloseOnLastPage ? (
+        <CloseButton onClick={onCloseOnLastPage}>
           <SolidErrorIcon className={StyledSVG.styledComponentId} />
         </CloseButton>
       ) : (

--- a/src/lib/pagination/compact.tsx
+++ b/src/lib/pagination/compact.tsx
@@ -62,6 +62,7 @@ interface CompactPaginationProps {
   numPages: number;
   //eslint-disable-next-line @typescript-eslint/ban-types
   callback: Function;
+  closeOnLastPage?: () => void;
   label?: ReactNode;
   className?: string;
 }
@@ -70,11 +71,12 @@ const CompactPagination: React.FC<CompactPaginationProps> = ({
   currentPage,
   numPages,
   callback,
+  closeOnLastPage,
   label,
   className,
 }) => {
   const [{ incrementPage, decrementPage, minPageReached, maxPageReached }] =
-    usePagination(currentPage, numPages, callback);
+    usePagination(currentPage, numPages, callback, closeOnLastPage);
 
   return (
     <Wrapper {...{ className }}>
@@ -82,7 +84,10 @@ const CompactPagination: React.FC<CompactPaginationProps> = ({
       <LeftArrow disabled={minPageReached} onClick={decrementPage}>
         <Arrow className={StyledSVG.styledComponentId} />
       </LeftArrow>
-      <RightArrow disabled={maxPageReached} onClick={incrementPage}>
+      <RightArrow
+        disabled={maxPageReached && !closeOnLastPage}
+        onClick={incrementPage}
+      >
         <Arrow className={StyledSVG.styledComponentId} />
       </RightArrow>
     </Wrapper>

--- a/src/lib/pagination/compact.tsx
+++ b/src/lib/pagination/compact.tsx
@@ -75,8 +75,7 @@ const CloseButton = styled(ArrowButton)`
 interface CompactPaginationProps {
   currentPage: number;
   numPages: number;
-  //eslint-disable-next-line @typescript-eslint/ban-types
-  callback: Function;
+  callback: (newPage: number) => void;
   onCloseOnLastPage?: () => void;
   label?: ReactNode;
   className?: string;

--- a/src/lib/pagination/compact.tsx
+++ b/src/lib/pagination/compact.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react";
 import styled from "styled-components";
 import usePagination from "../../hooks/pagination/use-pagination";
 import Arrow from "../../assets/svgs/arrows/circle-left.svg";
+import SolidErrorIcon from "../../assets/svgs/status-icons/solid-error.svg";
 import { borderBox, button, small, svg } from "../../styles/common-style";
 
 const Wrapper = styled.div`
@@ -57,6 +58,20 @@ const RightArrow = styled(ArrowButton)`
   }
 `;
 
+const CloseButton = styled(ArrowButton)`
+  margin-left: 8px;
+
+  & ${StyledSVG} {
+    fill: ${(props) => props.theme.klerosUIComponentsPrimaryBlue};
+  }
+
+  :hover:enabled {
+    & ${StyledSVG} {
+      fill: ${({ theme }) => theme.klerosUIComponentsSecondaryBlue};
+    }
+  }
+`;
+
 interface CompactPaginationProps {
   currentPage: number;
   numPages: number;
@@ -84,12 +99,15 @@ const CompactPagination: React.FC<CompactPaginationProps> = ({
       <LeftArrow disabled={minPageReached} onClick={decrementPage}>
         <Arrow className={StyledSVG.styledComponentId} />
       </LeftArrow>
-      <RightArrow
-        disabled={maxPageReached && !closeOnLastPage}
-        onClick={incrementPage}
-      >
-        <Arrow className={StyledSVG.styledComponentId} />
-      </RightArrow>
+      {currentPage === numPages && closeOnLastPage ? (
+        <CloseButton onClick={closeOnLastPage}>
+          <SolidErrorIcon className={StyledSVG.styledComponentId} />
+        </CloseButton>
+      ) : (
+        <RightArrow disabled={maxPageReached} onClick={incrementPage}>
+          <Arrow className={StyledSVG.styledComponentId} />
+        </RightArrow>
+      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
visual demonstration:

https://github.com/kleros/ui-components-library/assets/102478601/c1bf88c2-825c-4448-8a5d-20b707c1b373

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the pagination functionality by adding a new optional callback for closing on the last page.

### Detailed summary
- Updated `use-pagination` hook to accept an optional `onCloseOnLastPage` callback.
- Added a new `CloseButton` component with an `onClick` event to trigger the `onCloseOnLastPage` callback.
- Updated `CompactPagination` component to conditionally render the `CloseButton` based on the current page being the last page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `onCloseOnLastPage` function prop to `CompactPagination`, allowing users to specify an action when the last page is reached.
  - Enhanced `usePagination` hook to accept an `onCloseOnLastPage` parameter for customized behavior on the last page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->