### PR TITLE
feat: custom-counter-arrows-in-number-field

### DIFF
--- a/src/assets/svgs/arrows/field-arrow-down.svg
+++ b/src/assets/svgs/arrows/field-arrow-down.svg
@@ -1,0 +1,25 @@
+<svg
+  viewBox="0 0 512 512"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  fill="#000000"
+  transform="matrix(1, 0, 0, -1, 0, 0)"
+><g id="SVGRepo_bgCarrier" stroke-width="0" /><g
+    id="SVGRepo_tracerCarrier"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  /><g id="SVGRepo_iconCarrier"> <title>triangle-filled</title> <g
+      id="Page-1"
+      stroke="none"
+      stroke-width="1"
+      fill="none"
+      fill-rule="evenodd"
+    > <g
+        id="drop"
+        fill="#000000"
+        transform="translate(32.000000, 42.666667)"
+      > <path
+          d="M246.312928,5.62892705 C252.927596,9.40873724 258.409564,14.8907053 262.189374,21.5053731 L444.667042,340.84129 C456.358134,361.300701 449.250007,387.363834 428.790595,399.054926 C422.34376,402.738832 415.04715,404.676552 407.622001,404.676552 L42.6666667,404.676552 C19.1025173,404.676552 7.10542736e-15,385.574034 7.10542736e-15,362.009885 C7.10542736e-15,354.584736 1.93772021,347.288125 5.62162594,340.84129 L188.099293,21.5053731 C199.790385,1.04596203 225.853517,-6.06216498 246.312928,5.62892705 Z"
+          id="Combined-Shape"
+        > </path> </g> </g> </g></svg>

--- a/src/assets/svgs/arrows/field-arrow-up.svg
+++ b/src/assets/svgs/arrows/field-arrow-up.svg
@@ -1,0 +1,24 @@
+<svg
+  viewBox="0 0 512 512"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  fill="#000000"
+><g id="SVGRepo_bgCarrier" stroke-width="0" /><g
+    id="SVGRepo_tracerCarrier"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  /><g id="SVGRepo_iconCarrier"> <title>triangle-filled</title> <g
+      id="Page-1"
+      stroke="none"
+      stroke-width="1"
+      fill="none"
+      fill-rule="evenodd"
+    > <g
+        id="drop"
+        fill="#000000"
+        transform="translate(32.000000, 42.666667)"
+      > <path
+          d="M246.312928,5.62892705 C252.927596,9.40873724 258.409564,14.8907053 262.189374,21.5053731 L444.667042,340.84129 C456.358134,361.300701 449.250007,387.363834 428.790595,399.054926 C422.34376,402.738832 415.04715,404.676552 407.622001,404.676552 L42.6666667,404.676552 C19.1025173,404.676552 7.10542736e-15,385.574034 7.10542736e-15,362.009885 C7.10542736e-15,354.584736 1.93772021,347.288125 5.62162594,340.84129 L188.099293,21.5053731 C199.790385,1.04596203 225.853517,-6.06216498 246.312928,5.62892705 Z"
+          id="Combined-Shape"
+        > </path> </g> </g> </g></svg>

--- a/src/examples/form.tsx
+++ b/src/examples/form.tsx
@@ -5,6 +5,7 @@ import Searchbar from "../lib/form/searchbar";
 import Textarea from "../lib/form/textarea";
 import Slider from "../lib/form/slider";
 import Datepicker from "../lib/form/datepicker";
+import Telegram from "../assets/svgs/telegram.svg";
 
 const Form = () => {
   const [value, setValue] = useState(1);
@@ -26,6 +27,8 @@ const Form = () => {
         variant="success"
         message="success msg"
       />
+      <Field placeholder={"Number"} type="number" Icon={Telegram} />
+      <Field placeholder={"Number"} type="number" />
       <Searchbar />
       <Textarea
         placeholder={"eg. longer text"}

--- a/src/lib/form/field.tsx
+++ b/src/lib/form/field.tsx
@@ -109,11 +109,13 @@ const ArrowsContainer = styled.div<{
 }>`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
   position: absolute;
-  height: 17px;
+  height: 100%;
   width: 14px;
-  top: 14px;
+  gap: 4px;
+  top: 0;
   right: ${({ Icon, variant }) => {
     if (Icon) return "48px";
     if (variant) return "36px";
@@ -122,13 +124,14 @@ const ArrowsContainer = styled.div<{
 `;
 
 const ArrowButton = styled.button`
-  height: 10px;
-  width: 100%;
+  height: 14px;
+  width: 14px;
   display: flex;
   justify-content: center;
   align-items: center;
   background: transparent;
   border: none;
+  border-radius: 3px;
   padding: 0;
 
   cursor: pointer;

--- a/src/lib/form/field.tsx
+++ b/src/lib/form/field.tsx
@@ -214,11 +214,11 @@ const Field: React.FC<FieldProps> = ({
           >
             <StyledArrowIcon as={UpArrowIcon} />
           </ArrowButton>
-          <ArrowButton aria-label="decrement">
-            <StyledArrowIcon
-              as={DownArrowIcon}
-              onClick={() => inputRef?.current?.stepDown()}
-            />
+          <ArrowButton
+            aria-label="decrement"
+            onClick={() => inputRef?.current?.stepDown()}
+          >
+            <StyledArrowIcon as={DownArrowIcon} />
           </ArrowButton>
         </ArrowsContainer>
       )}

--- a/src/lib/form/field.tsx
+++ b/src/lib/form/field.tsx
@@ -1,10 +1,14 @@
-import React, { InputHTMLAttributes } from "react";
+import React, { InputHTMLAttributes, useRef } from "react";
 import styled, { css } from "styled-components";
 import SuccessIcon from "../../assets/svgs/status-icons/success.svg";
 import WarningIcon from "../../assets/svgs/status-icons/warning.svg";
 import ErrorIcon from "../../assets/svgs/status-icons/error.svg";
 import InfoIcon from "../../assets/svgs/status-icons/info.svg";
+import UpArrowIcon from "../../assets/svgs/arrows/field-arrow-up.svg";
+import DownArrowIcon from "../../assets/svgs/arrows/field-arrow-down.svg";
+
 import { borderBox, small, svg } from "../../styles/common-style";
+import { useHover } from "usehooks-ts";
 
 export type VariantProp = {
   variant?: "success" | "warning" | "error" | string;
@@ -80,12 +84,65 @@ const StyledInput = styled.input<{
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 16px;
-  padding-right: ${({ Icon, variant }) => {
-    if (Icon) return "56px";
-    if (variant) return "44px";
-    return "16px";
+  padding-right: ${({ Icon, variant, type }) => {
+    if (Icon) return type === "number" ? "64px" : "56px";
+    if (variant) return type === "number" ? "52px" : "44px";
+    return type === "number" ? "30px" : "16px";
   }};
+
+  /* Chrome, Safari, Edge, Opera */
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  -moz-appearance: textfield;
+  appearance: textfield;
   ${baseInputStyle}
+`;
+
+const ArrowsContainer = styled.div<{
+  variant?: string;
+  Icon?: React.FC<React.SVGAttributes<SVGElement>>;
+}>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  height: 17px;
+  width: 14px;
+  top: 14px;
+  right: ${({ Icon, variant }) => {
+    if (Icon) return "48px";
+    if (variant) return "36px";
+    return "12px";
+  }};
+`;
+
+const ArrowButton = styled.button`
+  height: 10px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+
+  cursor: pointer;
+  :hover {
+    background: ${(props) => props.theme.klerosUIComponentsStroke};
+  }
+`;
+
+const StyledArrowIcon = styled.svg`
+  width: 8px;
+  height: 8px;
+  path {
+    fill: ${(props) => props.theme.klerosUIComponentsSecondaryText};
+  }
 `;
 
 const StyledSVG = styled.svg``;
@@ -141,27 +198,49 @@ const Field: React.FC<FieldProps> = ({
   Icon,
   className,
   ...props
-}) => (
-  <Wrapper {...{ className }}>
-    <StyledInput {...{ variant, Icon, ...props }} />
-    {variant === "success" && <StyledSuccessIcon className="field-svg" />}
-    {variant === "warning" && <StyledWarningIcon className="field-svg" />}
-    {variant === "error" && <StyledErrorIcon className="field-svg" />}
-    {Icon && (
-      <IconContainer>
-        <StyledIconSVG as={Icon} />
-      </IconContainer>
-    )}
-    {message && (
-      <StyledMessage {...{ variant }}>
-        {variant === "info" && (
-          <InfoIcon className={StyledSVG.styledComponentId} />
-        )}
-        <StyledSmall {...{ variant }}>{message}</StyledSmall>
-      </StyledMessage>
-    )}
-  </Wrapper>
-);
+}) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hovering = useHover(wrapperRef);
+
+  return (
+    <Wrapper ref={wrapperRef} {...{ className }}>
+      <StyledInput ref={inputRef} {...{ variant, Icon, ...props }} />
+      {props.type === "number" && hovering && (
+        <ArrowsContainer className="field-arrows" {...{ variant, Icon }}>
+          <ArrowButton
+            aria-label="increment"
+            onClick={() => inputRef?.current?.stepUp()}
+          >
+            <StyledArrowIcon as={UpArrowIcon} />
+          </ArrowButton>
+          <ArrowButton aria-label="decrement">
+            <StyledArrowIcon
+              as={DownArrowIcon}
+              onClick={() => inputRef?.current?.stepDown()}
+            />
+          </ArrowButton>
+        </ArrowsContainer>
+      )}
+      {variant === "success" && <StyledSuccessIcon className="field-svg" />}
+      {variant === "warning" && <StyledWarningIcon className="field-svg" />}
+      {variant === "error" && <StyledErrorIcon className="field-svg" />}
+      {Icon && (
+        <IconContainer>
+          <StyledIconSVG as={Icon} />
+        </IconContainer>
+      )}
+      {message && (
+        <StyledMessage {...{ variant }}>
+          {variant === "info" && (
+            <InfoIcon className={StyledSVG.styledComponentId} />
+          )}
+          <StyledSmall {...{ variant }}>{message}</StyledSmall>
+        </StyledMessage>
+      )}
+    </Wrapper>
+  );
+};
 
 Field.displayName = "Field";
 


### PR DESCRIPTION
- Updates the style of counter arrows that show up when `Field` is of `type` of `number`
- Shows up when hovering only

<img width="288" alt="Screenshot 2024-10-04 at 2 08 30 PM" src="https://github.com/user-attachments/assets/07c5baee-0240-4ab9-a313-3efa3fb8b534">

<img width="295" alt="Screenshot 2024-10-04 at 2 08 45 PM" src="https://github.com/user-attachments/assets/465deba7-0f63-4abe-8820-48b0e58d5467">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `Form` component by adding a new `Field` that uses a `Telegram` icon and implements number input functionality with increment and decrement buttons. It also includes SVG assets for arrow icons and updates styling for better usability.

### Detailed summary
- Added import of `Telegram` SVG in `src/examples/form.tsx`.
- Introduced a new `Field` with `Telegram` icon in `Form`.
- Implemented increment and decrement buttons for number inputs in `Field`.
- Added new SVG assets for up and down arrows in `src/lib/form/field.tsx`.
- Updated padding logic in `StyledInput` for number type.
- Created `ArrowsContainer`, `ArrowButton`, and `StyledArrowIcon` styled components for arrow buttons.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new numeric input fields in the form with a placeholder and an optional Telegram icon.
	- Added increment and decrement buttons for numeric inputs to enhance user interaction.
	- Implemented hover detection for improved functionality of the input fields.

- **Bug Fixes**
	- Adjusted padding for number inputs to ensure consistent styling.

- **Documentation**
	- Updated component descriptions to reflect new features and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->