### PR TITLE
feat: custom-timeline-states

### DIFF
--- a/src/examples/timeline.tsx
+++ b/src/examples/timeline.tsx
@@ -93,6 +93,7 @@ const TimelineProgress = () => (
           party: "No",
           subtitle: "06 Jul 2023 12:00 UTC",
           variant: "#ca2314",
+          state: "loading",
         },
       ]}
     />

--- a/src/lib/progress/timeline/bullet.tsx
+++ b/src/lib/progress/timeline/bullet.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import styled from "styled-components";
+import styled, { css, keyframes } from "styled-components";
 import Spine, { VariantProp, variantColor } from "./spine";
 export type { VariantProp };
 import { h2, p, small } from "../../../styles/common-style";
@@ -8,10 +8,34 @@ export interface SideProp {
   rightSided?: boolean;
 }
 
-const Wrapper = styled.div<SideProp>`
+export interface StateProp {
+  state?: "loading" | "disabled" | "active";
+}
+
+const loading = keyframes`
+  0%{
+    opacity: 1;
+  }
+  50%{
+    opacity: 0.5;
+  }
+  100%{
+    opacity: 1;
+  }
+`;
+
+const Wrapper = styled.div<SideProp & StateProp>`
   display: flex;
+  position: relative;
+  opacity: ${({ state }) => (!state || state === "active" ? 1 : 0.5)};
   justify-content: ${({ rightSided }) =>
     rightSided ? "flex-start" : "flex-end"};
+  ${({ state }) =>
+    state === "loading"
+      ? css`
+          animation: ${loading} 2s ease-in-out infinite normal;
+        `
+      : "none"};
 `;
 
 const StyledTitle = styled.h2``;
@@ -78,7 +102,7 @@ const PartyTitleContainer = styled.div<SideProp>`
     rightSided ? "flex-start" : "flex-end"};
 `;
 
-interface BulletProps extends VariantProp, SideProp {
+interface BulletProps extends VariantProp, SideProp, StateProp {
   title: string;
   party: string | React.ReactElement;
   subtitle: string;
@@ -90,14 +114,17 @@ interface BulletProps extends VariantProp, SideProp {
 
 const Bullet: React.FC<BulletProps> = (props) => {
   const { title, party, subtitle, ...restProps } = props;
-  const { rightSided, variant, line, Icon, isLast, ...wrapperProps } =
+  const { rightSided, variant, line, Icon, isLast, state, ...wrapperProps } =
     restProps;
   const titleRef = useRef<HTMLHeadingElement>(null);
 
   return (
-    <Wrapper {...{ rightSided }} {...wrapperProps}>
+    <Wrapper {...{ rightSided, state }} {...wrapperProps}>
       <Spine {...{ variant, line, Icon, titleRef }} />
-      <TextContainer {...{ variant, rightSided, isLast }}>
+      <TextContainer
+        className="text-container"
+        {...{ variant, rightSided, isLast }}
+      >
         <PartyTitleContainer {...{ rightSided }}>
           <StyledTitle ref={titleRef}>{title}</StyledTitle>
           {typeof party === `string` ? (

--- a/src/lib/progress/timeline/bullet.tsx
+++ b/src/lib/progress/timeline/bullet.tsx
@@ -27,15 +27,21 @@ const loading = keyframes`
 const Wrapper = styled.div<SideProp & StateProp>`
   display: flex;
   position: relative;
-  opacity: ${({ state }) => (!state || state === "active" ? 1 : 0.5)};
   justify-content: ${({ rightSided }) =>
     rightSided ? "flex-start" : "flex-end"};
-  ${({ state }) =>
-    state === "loading"
-      ? css`
-          animation: ${loading} 2s ease-in-out infinite normal;
-        `
-      : "none"};
+  ${({ state }) => {
+    if (state === "disabled")
+      return css`
+        opacity: 0.5;
+      `;
+    if (state === "loading")
+      return css`
+        animation: ${loading} 2s ease-in-out infinite normal;
+      `;
+    return css`
+      opacity: 1;
+    `;
+  }}
 `;
 
 const StyledTitle = styled.h2``;

--- a/src/lib/progress/timeline/custom.tsx
+++ b/src/lib/progress/timeline/custom.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import styled from "styled-components";
-import Bullet, { SideProp, VariantProp } from "./bullet";
+import Bullet, { SideProp, StateProp, VariantProp } from "./bullet";
 import { borderBox } from "../../../styles/common-style";
 
-interface TimelineItem extends SideProp, VariantProp {
+interface TimelineItem extends SideProp, VariantProp, StateProp {
   title: string;
   party: string | React.ReactElement;
   subtitle: string;


### PR DESCRIPTION
- disabled
<img width="343" alt="Screenshot 2024-12-09 at 2 08 37 PM" src="https://github.com/user-attachments/assets/16a795bc-fa26-41e8-8fad-e7637c3f410e">

- loading

https://github.com/user-attachments/assets/9d47a5b7-c527-4e6c-96d8-ef03c2ff6ef4

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `state` property to manage the loading state in the timeline component, enhances the `Bullet` component with a loading animation, and updates the styling and interfaces to accommodate these changes.

### Detailed summary
- Added `state: "loading"` to the timeline item in `timeline.tsx`.
- Introduced `StateProp` interface in `bullet.tsx` for managing component states.
- Modified `TimelineItem` and `BulletProps` interfaces to include `StateProp`.
- Implemented loading animation in the `Wrapper` styled component.
- Updated `Bullet` component to utilize the new `state` prop for rendering.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a loading state for timeline items in the CustomTimeline component.
	- Enhanced the Bullet component to visually represent different states including loading, disabled, and active with animations.

- **Bug Fixes**
	- Updated the TimelineItem interface to accommodate the new state property, ensuring proper data structure for timeline items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->