### PR TITLE
feat: use transition instead of animation for the tooltips

### DIFF
--- a/src/lib/tooltip/index.tsx
+++ b/src/lib/tooltip/index.tsx
@@ -87,7 +87,7 @@ const Tip = styled.div<TooltipBaseProps>`
 
 const StyledTooltip = styled.span<TooltipBaseProps>`
   ${borderBox}
-  transition: opacity 0.5s, visibility 0.5s;
+  transition: opacity 200ms ease-in, visibility 200ms ease-in;
   ${({ place, theme, small }) => css`
     visibility: hidden;
     opacity: 0%;

--- a/src/lib/tooltip/index.tsx
+++ b/src/lib/tooltip/index.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import styled, { css } from "styled-components";
-import {
-  borderBox,
-  fadeIn,
-  small as smallStyle,
-} from "../../styles/common-style";
+import { borderBox, small as smallStyle } from "../../styles/common-style";
 
 export interface TooltipBaseProps {
   place?: "left" | "right" | "top" | "bottom";
@@ -91,8 +87,10 @@ const Tip = styled.div<TooltipBaseProps>`
 
 const StyledTooltip = styled.span<TooltipBaseProps>`
   ${borderBox}
+  transition: opacity 0.5s, visibility 0.5s;
   ${({ place, theme, small }) => css`
     visibility: hidden;
+    opacity: 0%;
     position: absolute;
     z-index: 1;
     width: max-content;
@@ -145,7 +143,7 @@ const Wrapper = styled.div`
 
   &:hover ${StyledTooltip} {
     visibility: visible;
-    animation: ${fadeIn} 200ms ease-in;
+    opacity: 100%;
   }
 `;
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refining the `StyledTooltip` component in the `src/lib/tooltip/index.tsx` file by enhancing its styling and animations.

### Detailed summary
- Removed the import of `fadeIn` from `../../styles/common-style`.
- Added a `transition` property to `StyledTooltip` for smoother opacity and visibility changes.
- Updated the `opacity` from `0%` to `100%` on hover for better visibility.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tooltip appearance with updated opacity and visibility transitions.
	- Simplified hover effect for tooltip visibility.

- **Bug Fixes**
	- Removed unused animation to streamline tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->