### PR TITLE
feat: dropdown-cascader-number-bubble

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const StyledDiv = styled.div`
   align-items: center;
   flex-wrap: wrap;
   padding: 36px 36px;
+  overflow: scroll;
   background: ${(props) => props.theme.klerosUIComponentsLightBackground};
   transition: background ease
     ${(props) => props.theme.klerosUIComponentsTransitionSpeed};

--- a/src/lib/dropdown/base-item.tsx
+++ b/src/lib/dropdown/base-item.tsx
@@ -51,6 +51,19 @@ const StyledDot = styled(Dot)`
   margin-right: 8px;
 `;
 
+const CountDisplay = styled.label`
+  width: 24px;
+  height: 24px;
+  border: 1px solid ${({ theme }) => theme.klerosUIComponentsPrimaryBlue};
+  border-radius: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: 12px;
+  color: ${({ theme }) => theme.klerosUIComponentsPrimaryBlue};
+`;
 export interface IBaseItem
   extends IItem,
     Omit<React.HTMLAttributes<HTMLDivElement>, "onClick"> {
@@ -58,6 +71,7 @@ export interface IBaseItem
   Icon?: React.FC<React.SVGAttributes<SVGElement>>;
   icon?: React.ReactNode;
   dot?: string;
+  childrenCount?: number;
   onClick?: () => void;
 }
 
@@ -67,6 +81,7 @@ const BaseItem: React.FC<IBaseItem> = ({
   icon,
   dot,
   onClick,
+  childrenCount,
   ...props
 }) => (
   <Item
@@ -76,6 +91,11 @@ const BaseItem: React.FC<IBaseItem> = ({
     {icon ?? (Icon && <Icon className="item-icon" />)}
     {dot && <StyledDot color={dot} />}
     <StyledText>{text}</StyledText>
+    {childrenCount !== undefined ? (
+      <CountDisplay className="count-display">
+        <span>{childrenCount}</span>
+      </CountDisplay>
+    ) : null}
   </Item>
 );
 

--- a/src/lib/dropdown/cascader/item-container.tsx
+++ b/src/lib/dropdown/cascader/item-container.tsx
@@ -16,6 +16,19 @@ export const StyledBaseItem = styled(BaseItem)`
         ? theme.klerosUIComponentsPrimaryBlue
         : theme.klerosUIComponentsStroke};
   }
+
+  .count-display {
+    position: absolute;
+    right: 32px;
+    border-color: ${({ selected, theme }) =>
+      selected
+        ? theme.klerosUIComponentsPrimaryBlue
+        : theme.klerosUIComponentsStroke};
+    color: ${({ selected, theme }) =>
+      selected
+        ? theme.klerosUIComponentsPrimaryBlue
+        : theme.klerosUIComponentsStroke};
+  }
 `;
 
 export interface IItem {
@@ -42,6 +55,7 @@ const ItemContainer: React.FC<IItemContainer> = ({
         text={item.label}
         Icon={item.children && LightArrow}
         onClick={() => onChange(item)}
+        childrenCount={item.children?.length}
         selected={item.value === layer.selected}
       />
     ))}


### PR DESCRIPTION
https://www.figma.com/design/b7DEUKDeHlOl4ocDTMv7UIhZ/Kleros?node-id=18592-165337&version-id=2167237401428795723&m=dev

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `CountDisplay` component to show the number of children items in a dropdown. It enhances the `ItemContainer` and `BaseItem` components to incorporate this new display, improving the user interface by providing visual feedback on item counts.

### Detailed summary
- Added `overflow: scroll;` to the `src/App.tsx` styles.
- Introduced a new `.count-display` styled component in `src/lib/dropdown/cascader/item-container.tsx`.
- Updated `IItem` interface to include `childrenCount`.
- Enhanced `BaseItem` to display `CountDisplay` with the child count when available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a count display for dropdown items to show the number of child items
  - Implemented scrolling behavior in a styled component

- **Style**
  - Updated styling for count display with theme-based colors
  - Added positioning for count label in dropdown items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->