### PR TITLE
fix: add toString config to useBigNumberField

### DIFF
--- a/src/lib/form/bignumber-field/useBigNumberField.tsx
+++ b/src/lib/form/bignumber-field/useBigNumberField.tsx
@@ -86,6 +86,7 @@ export function useBigNumberField(props: BigNumberFieldProps) {
     };
 
     BigNumber.config({
+      EXPONENTIAL_AT: 1e9,
       FORMAT: formatConfig,
     });
   }, [props.formatOptions]);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on configuring the `BigNumber` library to set specific formatting options, particularly adjusting the `EXPONENTIAL_AT` threshold.

### Detailed summary
- Added configuration for `BigNumber` with:
  - `EXPONENTIAL_AT` set to `1e9`
  - `FORMAT` set to `formatConfig`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->