### PR TITLE
fix: update light theme --klerosUIComponentsTintMedium color

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -26,7 +26,7 @@
     --klerosUIComponentsError: #f60c36;
     --klerosUIComponentsErrorLight: #fef0f3;
     --klerosUIComponentsTint: #d14eff;
-    --klerosUIComponentsTintMedium: #401d6c;
+    --klerosUIComponentsTintMedium: #fcf4ff;
     --klerosUIComponentsTintPurple: #f4f0fa;
 
     --klerosUIComponentsTransitionSpeed: 0.25s;


### PR DESCRIPTION
Sets the correct light theme color for  `--klerosUIComponentsTintMedium`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating color variables in the `theme.css` file, specifically modifying the value of `--klerosUIComponentsTintMedium` to a new color.

### Detailed summary
- Changed the value of `--klerosUIComponentsTintMedium` from `#401d6c` to `#fcf4ff`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the base theme color for improved visual appearance by changing a primary tint from dark purple to light lavender. This affects the look and feel of the standard (non-dark) theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->